### PR TITLE
MOD add&changeParamDefaultValue

### DIFF
--- a/launch/teleop_joy.launch.yaml
+++ b/launch/teleop_joy.launch.yaml
@@ -1,21 +1,26 @@
 launch:
-    - node_container:
-        pkg: "rclcpp_components"
-        exec: "component_container"
-        name: "teleop_joy_container"
-        namespace: ""
-        composable_node:
-        -
-            pkg: joy
-            plugin: "joy::Joy"
-            name: "joy"
-        -
-            pkg: teleop_joy_component
-            plugin: "teleop_joy_component::TeleopJoy"
-            name: "teleop_joy_component"
-            param:
-            # - {name: assignment_file, value: JC-U3912TBK.yaml}
-            - {name: assignment_file, value: F710_D_input.yaml}
-            - {name: cmd_vel_topic_name, value: cmd_vel}
-            - {name: max.v, value: 0.3}
-            - {name: max.w, value: 0.5}
+- arg: {name: assignment_file, default: JC-U3912TBK.yaml}
+# - arg: {name: assignment_file, default: F710_D_input.yaml}
+- arg: {name: cmd_vel_topic_name, default: cmd_vel}
+- arg: {name: max.v, default: "0.3"}
+- arg: {name: max.w, default: "0.5"}
+
+- node_container:
+    pkg: "rclcpp_components"
+    exec: "component_container"
+    name: "teleop_joy_container"
+    namespace: ""
+    composable_node:
+    -
+        pkg: joy
+        plugin: "joy::Joy"
+        name: "joy"
+    -
+        pkg: teleop_joy_component
+        plugin: "teleop_joy_component::TeleopJoy"
+        name: "teleop_joy_component"
+        param:
+        - {name: assignment_file, value: $(var assignment_file)}
+        - {name: cmd_vel_topic_name, value: $(var cmd_vel_topic_name)}
+        - {name: max.v, value: $(var max.v)}
+        - {name: max.w, value: $(var max.w)}

--- a/src/teleop_joy_component.cpp
+++ b/src/teleop_joy_component.cpp
@@ -21,8 +21,8 @@ TeleopJoy::TeleopJoy(const rclcpp::NodeOptions & options)
 {
   this->declare_parameter<std::string>("assignment_file", "assignment.yaml");
   this->declare_parameter<std::string>("cmd_vel_topic_name", "cmd_vel");
-  this->declare_parameter<double>("max.v", 1.0);
-  this->declare_parameter<double>("max.w", 1.0);
+  this->declare_parameter<double>("max.v", 0.3);
+  this->declare_parameter<double>("max.w", 0.5);
 
   auto path = ament_index_cpp::get_package_share_directory("teleop_joy_component") + "/config/" +
     this->get_parameter("assignment_file").as_string();


### PR DESCRIPTION
- launch時にparam設定が反映されなかったため修正しました（`ros2 launch teleop_joy_component teleop_joy.launch.yaml assignment_file:=JC-U3912TBK.yaml cmd_vel_topic_name:=cmd_vel max.v:=0.3 max.w:=0.5`のようにparamを指定できるようにしました）
- デフォルトの速度値を小さくしました